### PR TITLE
Nedskaler til 0 pods før migrering av database

### DIFF
--- a/app-preprod.yaml
+++ b/app-preprod.yaml
@@ -23,8 +23,8 @@ spec:
   vault:
     enabled: true
   replicas:
-    min: 1
-    max: 1
+    min: 0
+    max: 0
     cpuThresholdPercentage: 50
   resources:
     limits:

--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -23,8 +23,8 @@ spec:
   vault:
     enabled: true
   replicas:
-    min: 1
-    max: 1
+    min: 0
+    max: 0
     cpuThresholdPercentage: 50
   resources:
     limits:


### PR DESCRIPTION
Dette er første steg i migrering til ny db. Nedskaler til 0 pods slik at det ikke blir noe trafikk mot db under export og import av databasen.

Avtalt export og import av db skal skje kl 12.30. Merger denne kl 12:15