### PR TITLE
Sett datasource url til ny db

### DIFF
--- a/app-preprod.yaml
+++ b/app-preprod.yaml
@@ -23,8 +23,8 @@ spec:
   vault:
     enabled: true
   replicas:
-    min: 0
-    max: 0
+    min: 1
+    max: 1
     cpuThresholdPercentage: 50
   resources:
     limits:

--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -23,8 +23,8 @@ spec:
   vault:
     enabled: true
   replicas:
-    min: 0
-    max: 0
+    min: 1
+    max: 1
     cpuThresholdPercentage: 50
   resources:
     limits:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://A01DBVL020.adeo.no:5432/familie-ef-infotrygd-feed
+    url: jdbc:postgresql://A01DBVL036.adeo.no:5432/familie-ef-infotrygd-feed-15
 
 no.nav.security.jwt:
   issuer.sts:

--- a/src/main/resources/bootstrap-prod.yaml
+++ b/src/main/resources/bootstrap-prod.yaml
@@ -10,7 +10,7 @@ spring:
         lifecycle.enabled: true
       database:
         enabled: true
-        role: familie-ef-infotrygd-feed-admin
+        role: familie-ef-infotrygd-feed-15-admin
         backend: postgresql/prod-fss
       authentication: KUBERNETES
       kubernetes:


### PR DESCRIPTION
Skaler antall familie-ef-infotrygd-feed pods ned til 0
DBA tar en export og import av db
Sjekke sekvenser, index osv.
Merge denne PR'n. Ved deploy blir det skalert til normal antall pods igjen
Dobbelsjekk funksjonalitet i prod med testkall
Ved større feil så kan vi alltid reverte tilbake til bruk av den gamle databasen ved å reverte denne PR'n

Database + vault allerede satt opp her:
https://github.com/navikt/database-iac/pull/636
https://github.com/navikt/vault-iac/pull/5650