### PR TITLE
Støtte for secure logs fjernes

### DIFF
--- a/app-preprod.yaml
+++ b/app-preprod.yaml
@@ -51,8 +51,6 @@ spec:
       rules:
         - application: logging
           namespace: nais-system
-  secureLogs:
-    enabled: true
   azure:
     application:
       enabled: true

--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -33,8 +33,6 @@ spec:
     requests:
       memory: 512Mi
       cpu: 200m
-  secureLogs:
-    enabled: true
   ingresses:
     - https://familie-ef-infotrygd-feed.intern.nav.no
     - https://familie-ef-infotrygd-feed.nais.adeo.no

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,19 +3,6 @@
     <property name="ROOT_LOG_LEVEL" value="INFO"/>
 
     <!-- Logger for sensitive data -->
-    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/secure-logs/secure.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>1</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>50MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-    </appender>
-
     <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -29,7 +16,6 @@
     </appender>
 
     <logger name="secureLogger" level="INFO" additivity="false">
-        <appender-ref ref="secureLog"/>
         <appender-ref ref="team-logs"/>
     </logger>
 


### PR DESCRIPTION
Støtte for secure logs fjernes og vi må nå kun forholde oss til Team Logs.

Hvorfor er denne endringen nødvendig? ✨
Støtte for secure logs fjernes og vi må nå kun forholde oss til Team Logs.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-26894).

Så på denne for inspiriasjon → https://github.com/navikt/familie-klage/pull/757