### PR TITLE
Returner string som følge av sb4

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/feed/rest/OpprettEntryController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/feed/rest/OpprettEntryController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(
     "/api/entry",
     consumes = [MediaType.APPLICATION_JSON_VALUE],
-    produces = [MediaType.APPLICATION_JSON_VALUE],
+    produces = [MediaType.TEXT_PLAIN_VALUE],
 )
 @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
 class OpprettEntryController(
@@ -24,7 +24,7 @@ class OpprettEntryController(
     @PostMapping("/periode")
     fun lagNyPeriodeMelding(
         @RequestBody opprettEntryDto: OpprettPeriodeHendelseDto,
-    ): ResponseEntity<Any> {
+    ): ResponseEntity<String> {
         if (opprettEntryDto.type != StønadType.OVERGANGSSTØNAD) {
             return ResponseEntity
                 .badRequest()

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/feed/rest/OpprettEntryController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/feed/rest/OpprettEntryController.kt
@@ -31,6 +31,6 @@ class OpprettEntryController(
                 .body("Har ikke satt opp mappinger for andre typer enn for overgangsstønad")
         }
         infotrygdFeedService.opprettNyFeed(opprettEntryDto)
-        return ResponseEntity.ok().build()
+        return ResponseEntity.ok("OK")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/infotrygd/feed/rest/OpprettEntryController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/infotrygd/feed/rest/OpprettEntryController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.infotrygd.feed.rest
 import no.nav.familie.ef.infotrygd.feed.service.InfotrygdFeedService
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.ef.infotrygd.OpprettPeriodeHendelseDto
+import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(
     "/api/entry",
     consumes = [MediaType.APPLICATION_JSON_VALUE],
-    produces = [MediaType.TEXT_PLAIN_VALUE],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
 )
 @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
 class OpprettEntryController(
@@ -24,13 +25,13 @@ class OpprettEntryController(
     @PostMapping("/periode")
     fun lagNyPeriodeMelding(
         @RequestBody opprettEntryDto: OpprettPeriodeHendelseDto,
-    ): ResponseEntity<String> {
+    ): ResponseEntity<Ressurs<String>> {
         if (opprettEntryDto.type != StønadType.OVERGANGSSTØNAD) {
             return ResponseEntity
                 .badRequest()
-                .body("Har ikke satt opp mappinger for andre typer enn for overgangsstønad")
+                .body(Ressurs.failure("Har ikke satt opp mappinger for andre typer enn for overgangsstønad"))
         }
         infotrygdFeedService.opprettNyFeed(opprettEntryDto)
-        return ResponseEntity.ok("OK")
+        return ResponseEntity.ok(Ressurs.success("OK"))
     }
 }


### PR DESCRIPTION
Spring boot 4 er strenger på semantikk og api-kontrakter. Returnerer derfor OK som Ressurs<String> for å være bakoverkompatibel (json-struktur) og ikke returnere null. 